### PR TITLE
Add ability for users to input custom properties to readwise imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logseq-readwise-plugin",
-  "version": "3.3",
+  "version": "3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "logseq-readwise-plugin",
-      "version": "3.3",
+      "version": "3.7",
       "license": "MIT",
       "dependencies": {
         "@logseq/libs": "latest",

--- a/src/App.css
+++ b/src/App.css
@@ -203,7 +203,8 @@ Correct the inability to style clickable types in iOS and Safari.
 */
 
 button,
-[type='button'] {
+[type='button'],
+[type='submit'] {
   -webkit-appearance: button;
 }
 
@@ -705,6 +706,14 @@ video {
     -webkit-animation-timing-function: cubic-bezier(0,0,0.2,1);
             animation-timing-function: cubic-bezier(0,0,0.2,1);
   }
+}
+
+.list-outside {
+  list-style-position: outside;
+}
+
+.list-none {
+  list-style-type: none;
 }
 
 .flex-row {

--- a/src/handleHighlights.ts
+++ b/src/handleHighlights.ts
@@ -64,6 +64,12 @@ const getHighlightsForBook = async (
       continue;
     }
 
+    // Get custom properties
+    const customPropertiesStr = logseq.settings['customSyncProperties'].reduce((str, { prop, value }) => {
+      return `${ str }
+      ${prop}:: ${value}`;
+    }, '');
+
     // Prepare latest highlights for logeq insertion
     let latestHighlightsArr;
     if (b.source === 'kindle') {
@@ -148,11 +154,12 @@ const getHighlightsForBook = async (
       await logseq.Editor.updateBlock(
         headerBlock.uuid,
         `retrieved:: ${utils.blockTitle(preferredDateFormat)}
-              author:: [[${b.author}]]
-              category:: [[${b.category}]]
-              source:: [[${b.source}]]
-              tags:: ${prepareTags(b.tags)}
-              `
+          author:: [[${b.author}]]
+          category:: [[${b.category}]]
+          source:: [[${b.source}]]
+          ${ customPropertiesStr }
+          tags:: ${prepareTags(b.tags)}
+          `
       );
     } else {
       // Insert only new highlights in Readwise Highlights block
@@ -205,6 +212,7 @@ const getHighlightsForBook = async (
               author:: [[${b.author}]]
               category:: [[${b.category}]]
               source:: [[${b.source}]]
+              ${customPropertiesStr}
               `
       );
     }


### PR DESCRIPTION
I wanted to be able to add a custom property to the readwise imports, specifically a property `referrer: [[Readwise]]`. This was my attempt to do so.

I would love some insight into how to test this locally. As it stands, it would not be styled properly and truly I haven't confirmed that this works. I tried running it locally using the npm scripts, but it didn't work. What I haven't tried is loading the package manually, via manifest and my personal github.

I will try that tomorrow, but in the off chance you take a look at this in the meantime to see if this is something you'd even want. Otherwise, I will just continue to try and run it from my personal repo.