### PR TITLE
Add support for Org-mode

### DIFF
--- a/src/handleHighlights.ts
+++ b/src/handleHighlights.ts
@@ -39,7 +39,8 @@ const getHighlightsForBook = async (
     if(preferredFormat==="markdown"){
       return `[${text}](${link})`;
     }if(preferredFormat==="org"){
-      return `[[${link}][${text}]]`;
+      // return `[[${link}][${text}]]`;
+      return `${link}`; // for now see bug https://github.com/logseq/logseq/issues/4191
     }
   }
   function insertImage(text,link){


### PR DESCRIPTION
This PR enables the plugin to be used when the user has chosen org mode as the format. 

One problem is that Readwise does not support org syntax and hence the pulled content is still as markdown. Nevertheless, logseq renders it. 


Things to fix:
- [ ] Random highlight has some logic to look at the "## Readwise Highlights", this needs to be updated. 