### PR TITLE
Ignore sources with no highlights in sync

### DIFF
--- a/src/components/Sync.tsx
+++ b/src/components/Sync.tsx
@@ -60,6 +60,11 @@ const Sync = (props: {
         (b) => new Date(b.updated) > new Date(logseq.settings.latestRetrieved)
       );
 
+      if (latestHighlights.length === 0) {
+        console.log(`No highlights found for '${b.title}'`);
+        continue;
+      }
+
       // Prepare latest highlights for logeq insertion
       let latestHighlightsArr: any[] = [];
       if (b.source === 'kindle') {


### PR DESCRIPTION
A source that has no highlights currently freezes the sync when
encountered and prevents importing all sources.

This skips sources were no highlights can be found.

The fix is identical to the work done [here](https://github.com/hkgnp/logseq-readwise-plugin/pull/3) but was not part of the code any more

#15 